### PR TITLE
feat!: send audit logs to log analytics

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,12 +25,14 @@ No modules.
 | Name | Type |
 |------|------|
 | [azurerm_container_registry.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/container_registry) | resource |
+| [azurerm_monitor_diagnostic_setting.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_diagnostic_setting) | resource |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_location"></a> [location](#input\_location) | The supported Azure location where the resources exist. | `string` | n/a | yes |
+| <a name="input_log_analytics_workspace_id"></a> [log\_analytics\_workspace\_id](#input\_log\_analytics\_workspace\_id) | The ID of the Log Analytics workspace to send diagnostics to. | `string` | n/a | yes |
 | <a name="input_registry_name"></a> [registry\_name](#input\_registry\_name) | The name of this Container registry. | `any` | n/a | yes |
 | <a name="input_resource_group_name"></a> [resource\_group\_name](#input\_resource\_group\_name) | The name of the resource group in which to create the resources. | `string` | n/a | yes |
 | <a name="input_sku"></a> [sku](#input\_sku) | The SKU tier for the Container Registry. | `string` | `"Basic"` | no |

--- a/examples/basic/README.md
+++ b/examples/basic/README.md
@@ -2,5 +2,7 @@
 
 Terraform configuration which creates an Azure Container Registry with the following features:
 
+- 90 days log retention
 - Basic SKU
 - Administrator enabled
+- Send logs to Log Analytics Workspace

--- a/examples/basic/main.tf
+++ b/examples/basic/main.tf
@@ -11,11 +11,20 @@ resource "azurerm_resource_group" "this" {
   location = var.location
 }
 
+module "log_analytics" {
+  source = "github.com/equinor/terraform-azurerm-log-analytics?ref=v1.1.1"
+
+  workspace_name      = "log-${random_id.this.hex}"
+  resource_group_name = azurerm_resource_group.this.name
+  location            = azurerm_resource_group.this.location
+}
+
 module "acr" {
   # source = "github.com/equinor/terraform-azurerm-acr"
   source = "../.."
 
-  registry_name       = "cr${random_id.this.hex}"
-  location            = azurerm_resource_group.this.location
-  resource_group_name = azurerm_resource_group.this.name
+  registry_name              = "cr${random_id.this.hex}"
+  location                   = azurerm_resource_group.this.location
+  resource_group_name        = azurerm_resource_group.this.name
+  log_analytics_workspace_id = module.log_analytics.workspace_id
 }

--- a/main.tf
+++ b/main.tf
@@ -7,3 +7,19 @@ resource "azurerm_container_registry" "this" {
 
   tags = var.tags
 }
+
+resource "azurerm_monitor_diagnostic_setting" "this" {
+  name                       = "audit-logs"
+  target_resource_id         = azurerm_container_registry.this.id
+  log_analytics_workspace_id = var.log_analytics_workspace_id
+
+  log {
+    category = "ContainerRegistryLoginEvents"
+    enabled  = true
+
+    retention_policy {
+      days    = 0
+      enabled = false
+    }
+  }
+}

--- a/main.tf
+++ b/main.tf
@@ -22,4 +22,13 @@ resource "azurerm_monitor_diagnostic_setting" "this" {
       enabled = false
     }
   }
+  log {
+    category = "ContainerRegistryRepositoryEvents"
+    enabled  = true
+
+    retention_policy {
+      days    = 0
+      enabled = false
+    }
+  }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -18,6 +18,11 @@ variable "sku" {
   default     = "Basic"
 }
 
+variable "log_analytics_workspace_id" {
+  description = "The ID of the Log Analytics workspace to send diagnostics to."
+  type        = string
+}
+
 variable "tags" {
   description = "A mapping of tags to assign to the resources."
   type        = map(string)


### PR DESCRIPTION
Add diagnostic setting resource to send audit logs to Log analytics workspace.

BREAKING CHANGE: add variable `log_analytics_workspace_id`

Closes #16 