### PR TITLE
feat: set log analytics destination type and update min. provider version

### DIFF
--- a/examples/basic/main.tf
+++ b/examples/basic/main.tf
@@ -12,7 +12,7 @@ resource "azurerm_resource_group" "this" {
 }
 
 module "log_analytics" {
-  source = "github.com/equinor/terraform-azurerm-log-analytics?ref=v1.1.1"
+  source = "github.com/equinor/terraform-azurerm-log-analytics?ref=v1.3.0"
 
   workspace_name      = "log-${random_id.this.hex}"
   resource_group_name = azurerm_resource_group.this.name

--- a/examples/rbac/main.tf
+++ b/examples/rbac/main.tf
@@ -12,7 +12,7 @@ resource "azurerm_resource_group" "this" {
 }
 
 module "log_analytics" {
-  source = "github.com/equinor/terraform-azurerm-log-analytics?ref=v1.1.1"
+  source = "github.com/equinor/terraform-azurerm-log-analytics?ref=v1.3.0"
 
   workspace_name      = "log-${random_id.this.hex}"
   resource_group_name = azurerm_resource_group.this.name

--- a/examples/webhook/main.tf
+++ b/examples/webhook/main.tf
@@ -12,7 +12,7 @@ resource "azurerm_resource_group" "this" {
 }
 
 module "log_analytics" {
-  source = "github.com/equinor/terraform-azurerm-log-analytics?ref=v1.1.1"
+  source = "github.com/equinor/terraform-azurerm-log-analytics?ref=v1.3.0"
 
   workspace_name      = "log-${random_id.this.hex}"
   resource_group_name = azurerm_resource_group.this.name

--- a/main.tf
+++ b/main.tf
@@ -25,28 +25,17 @@ resource "azurerm_container_registry_webhook" "this" {
 }
 
 resource "azurerm_monitor_diagnostic_setting" "this" {
-  name                       = var.diagnostic_setting_name
-  target_resource_id         = azurerm_container_registry.this.id
-  log_analytics_workspace_id = var.log_analytics_workspace_id
+  name                           = var.diagnostic_setting_name
+  target_resource_id             = azurerm_container_registry.this.id
+  log_analytics_workspace_id     = var.log_analytics_workspace_id
+  log_analytics_destination_type = var.log_analytics_destination_type
 
-  log {
+  enabled_log {
     category = "ContainerRegistryLoginEvents"
-    enabled  = true
-
-    retention_policy {
-      days    = 0
-      enabled = false
-    }
   }
 
-  log {
+  enabled_log {
     category = "ContainerRegistryRepositoryEvents"
-    enabled  = true
-
-    retention_policy {
-      days    = 0
-      enabled = false
-    }
   }
 
   metric {

--- a/variables.tf
+++ b/variables.tf
@@ -35,6 +35,12 @@ variable "log_analytics_workspace_id" {
   type        = string
 }
 
+variable "log_analytics_destination_type" {
+  description = "The type of log analytics destination to use for this Log Analytics Workspace."
+  type        = string
+  default     = "AzureDiagnostics"
+}
+
 variable "diagnostic_setting_name" {
   description = "The name of this Diagnostic Setting."
   type        = string

--- a/versions.tf
+++ b/versions.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = ">= 1.0.0"
+  required_version = ">= 1.3.0"
 
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 2.31.0"
+      version = ">= 3.39.0"
     }
   }
 }


### PR DESCRIPTION
In the `enabled_log` block, `retention_policy` sub-block is being ommitted on purpose due to it being `false` by default.

Closes #29 