### PR TITLE
feat!: diasble acr admin account

### DIFF
--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -27,6 +27,7 @@ module "acr" {
   location                   = azurerm_resource_group.this.location
   resource_group_name        = azurerm_resource_group.this.name
   log_analytics_workspace_id = module.log_analytics.workspace_id
+  admin_enabled              = false
   sku                        = "Premium"
 
   # If one or more georeplications block is specified, they are expected to follow the alphabetic order on the location property.

--- a/main.tf
+++ b/main.tf
@@ -3,7 +3,7 @@ resource "azurerm_container_registry" "this" {
   location            = var.location
   resource_group_name = var.resource_group_name
   sku                 = var.sku
-  admin_enabled       = true
+  admin_enabled       = var.admin_enabled
 
   dynamic "georeplications" {
     for_each = var.georeplications

--- a/variables.tf
+++ b/variables.tf
@@ -18,6 +18,12 @@ variable "sku" {
   default     = "Basic"
 }
 
+variable "admin_enabled" {
+  description = "Is admin enabled for this Container Registry?"
+  type        = bool
+  default     = false
+}
+
 variable "georeplications" {
   description = "A list of properties of the geo-replication blocks for this Container Registry. Only availiable for Premium SKU."
 


### PR DESCRIPTION
Disable Azure Container Registry admin account by default to follow Azure recommendation.

BREAKING CHANGE: admin account disabled by default. To upgrade, set `admin_enabled` to `true`.