### PR TITLE
feat: simplify gep-replication configuration

### DIFF
--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -25,7 +25,6 @@ module "acr" {
   admin_enabled              = false
   sku                        = "Premium"
 
-  # If one or more georeplications block is specified, they are expected to follow the alphabetic order on the location property.
   georeplications = [
     {
       location                = "Norway East"

--- a/main.tf
+++ b/main.tf
@@ -26,8 +26,8 @@ resource "azurerm_container_registry" "this" {
 
   lifecycle {
     precondition {
-      condition     = length(var.georeplications) > 0 && var.sku == "Premium"
-      error_message = "Geo-replications can only configured if SKU is \"Premium\"."
+      condition     = var.sku == "Premium" ? length(var.georeplications) >= 0 : length(var.georeplications) == 0
+      error_message = "Geo-replications can only be configured if SKU is \"Premium\"."
     }
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -25,14 +25,19 @@ variable "admin_enabled" {
 }
 
 variable "georeplications" {
-  description = "A list of properties of the geo-replication blocks for this Container Registry. Only availiable for Premium SKU."
+  description = "A list of geo-replications to configure for this Container Registry. Only availiable for Premium SKU."
 
   type = list(object({
-    location                = string                # The location where this Container Registry should be geo-replicated.
-    zone_redundancy_enabled = optional(bool, false) # Is zone redundancy enabled for this replication location?
+    location                = string
+    zone_redundancy_enabled = optional(bool, false)
   }))
 
   default = []
+
+  validation {
+    condition     = length(var.georeplications) == length(distinct([for georeplication in var.georeplications : georeplication.location]))
+    error_message = "Value of property \"location\" must be unique for each object."
+  }
 }
 
 variable "log_analytics_workspace_id" {

--- a/variables.tf
+++ b/variables.tf
@@ -25,11 +25,11 @@ variable "admin_enabled" {
 }
 
 variable "georeplications" {
-  description = "A list of geo-replications to configure for this Container Registry. Only availiable for Premium SKU."
+  description = "A list of properties of the geo-replication blocks for this Container Registry. Only availiable for Premium SKU."
 
   type = list(object({
-    location                = string
-    zone_redundancy_enabled = optional(bool, false)
+    location                = string                # The location where this Container Registry should be geo-replicated.
+    zone_redundancy_enabled = optional(bool, false) # Is zone redundancy enabled for this replication location?
   }))
 
   default = []


### PR DESCRIPTION
- Create dynamic `georeplications` blocks in alphabetical order based on the `location` property.
- Add precondition to throw error when trying to configure geo-replication when SKU is not Premium.
- Validate that input variable `georeplications` does not contain objects with duplicate location.

Fixes #48